### PR TITLE
Change Vehicle.id field from Int to String

### DIFF
--- a/Sources/TeslaEndpoint.swift
+++ b/Sources/TeslaEndpoint.swift
@@ -12,14 +12,14 @@ enum Endpoint {
 	
 	case authentication
 	case vehicles
-	case mobileAccess(vehicleID: Int)
-	case allStates(vehicleID: Int)
-	case chargeState(vehicleID: Int)
-	case climateState(vehicleID: Int)
-	case driveState(vehicleID: Int)
-	case guiSettings(vehicleID: Int)
-	case vehicleState(vehicleID: Int)
-	case command(vehicleID: Int, command:VehicleCommand)
+	case mobileAccess(vehicleID: String)
+	case allStates(vehicleID: String)
+	case chargeState(vehicleID: String)
+	case climateState(vehicleID: String)
+	case driveState(vehicleID: String)
+	case guiSettings(vehicleID: String)
+	case vehicleState(vehicleID: String)
+	case command(vehicleID: String, command:VehicleCommand)
 }
 
 extension Endpoint {

--- a/Sources/Vehicle.swift
+++ b/Sources/Vehicle.swift
@@ -16,7 +16,7 @@ open class Vehicle: Mappable {
 	open var calendarEnabled: Bool?
 	open var color: String?
 	open var displayName: String?
-	open var id: Int?
+	open var id: String?
 	open var idS: String?
 	open var inService: Bool?
 	open var notificationsEnabled: Bool?
@@ -38,7 +38,7 @@ open class Vehicle: Mappable {
 		calendarEnabled			<- map["calendar_enabled"]
 		color					<- map["color"]
 		displayName				<- map["display_name"]
-		id						<- map["id"]
+		id						<- map["id_s"]
 		idS						<- map["id_s"]
 		inService				<- map["in_service"]
 		notificationsEnabled	<- map["notifications_enabled"]


### PR DESCRIPTION
Change the Vehicle.id field from Int to String to provide support on all architectures, not just 64-bit.