### PR TITLE
feat: add protocol for chargers

### DIFF
--- a/Sources/TeslaSwift/Model/NearbyChargingSites.swift
+++ b/Sources/TeslaSwift/Model/NearbyChargingSites.swift
@@ -9,6 +9,13 @@
 import Foundation
 import CoreLocation
 
+public protocol Charger {
+    var name: String? { get }
+    var type: String? { get }
+    var distance: Distance? { get }
+    var location: NearbyChargingSites.ChargerLocation? { get }
+}
+
 open class NearbyChargingSites: Codable {
 
     open var congestionSyncTimeUTCSecs: Int?
@@ -39,7 +46,7 @@ open class NearbyChargingSites: Codable {
         try container.encodeIfPresent(timestamp, forKey: .timestamp)
     }
 
-    public struct DestinationCharger: Codable {
+    public struct DestinationCharger: Codable, Charger {
         public var distance: Distance?
         public var location: ChargerLocation?
         public var name: String?
@@ -53,7 +60,7 @@ open class NearbyChargingSites: Codable {
         }
     }
 
-    public struct Supercharger: Codable {
+    public struct Supercharger: Codable, Charger {
         public var availableStalls: Int?
         public var distance: Distance?
         public var location: ChargerLocation?


### PR DESCRIPTION
## Description
This allows us to operate more generically on the commonalities between Superchargers & Destination Chargers.

## Example
Below demonstrates how it would be used in practice for a SwiftUI view. Allowing us to keep only one cell type instead of maintaining two.

```swift
struct ChargerCell: View {
    static let formatter: MeasurementFormatter = {
        let formatter = MeasurementFormatter()
        let numberFormatter = NumberFormatter()
        numberFormatter.maximumFractionDigits = 1
        numberFormatter.minimumFractionDigits = 0
        
        formatter.numberFormatter = numberFormatter

        return formatter
    }()
    
    var site: Charger // <---- generic charger protocol
    
    var body: some View {
        HStack {
            VStack(alignment: .leading) {
                site.name.map {
                    Text($0)
                        .font(.headline)
                }
                // specialize for display of superchargers, otherwise, always display distance / name at least
                if site is NearbyChargingSites.Supercharger {
                    HStack(spacing: 2) {
                            Text(String((site as? NearbyChargingSites.Supercharger)?.availableStalls ?? 0))
                            Group {
                                Text("/")
                                Text("\(String((site as? NearbyChargingSites.Supercharger)?.totalStalls ?? 0)) avail.")
                            }
                            .foregroundColor(.secondary)
                    }
                    .font(.subheadline)
                }
            }
            Spacer()
            VStack {
                Image(systemName: "bolt.fill")
                    .imageScale(.small)
                Text(Self.formatter.string(from: .init(value: site.distance?.miles ?? 0, unit: UnitLength.miles)))
                    .font(.caption)
                    .foregroundColor(.secondary)
            }
        }
        .padding(.vertical)
    }
}
```