### PR TITLE
Fix for Apple Watch (arm64_32) device

### DIFF
--- a/Sources/TeslaSwift/Model/Vehicle.swift
+++ b/Sources/TeslaSwift/Model/Vehicle.swift
@@ -31,7 +31,7 @@ open class Vehicle: Codable {
 	open var optionCodes: String?
 	open var state: String?
 	open var tokens: [String]?
-	open var vehicleID: Int?
+	open var vehicleID: Int64?
 	open var vin: String?
 	
 	// MARK: Codable protocol
@@ -84,7 +84,7 @@ open class Vehicle: Codable {
 		optionCodes = try? container.decode(String.self, forKey: .optionCodes)
 		state = try? container.decode(String.self, forKey: .state)
 		tokens = try? container.decode([String].self, forKey: .tokens)
-		vehicleID = try? container.decode(Int.self, forKey: .vehicleID)
+		vehicleID = try? container.decode(Int64.self, forKey: .vehicleID)
 		vin = try? container.decode(String.self, forKey: .vin)
 	}
 	

--- a/Sources/TeslaSwift/Model/VehicleExtended.swift
+++ b/Sources/TeslaSwift/Model/VehicleExtended.swift
@@ -10,7 +10,7 @@ import Foundation
 
 open class VehicleExtended: Vehicle {
 
-	open var userId: Int?
+	open var userId: Int64?
 	open var chargeState: ChargeState?
 	open var climateState: ClimateState?
 	open var driveState: DriveState?
@@ -35,7 +35,7 @@ open class VehicleExtended: Vehicle {
 	required public init(from decoder: Decoder) throws {
 		
 		let container = try decoder.container(keyedBy: CodingKeys.self)
-		userId = try container.decodeIfPresent(Int.self, forKey: .userId)
+		userId = try container.decodeIfPresent(Int64.self, forKey: .userId)
 		chargeState = try container.decodeIfPresent(ChargeState.self, forKey: .chargeState)
 		climateState = try container.decodeIfPresent(ClimateState.self, forKey: .climateState)
 		driveState = try container.decodeIfPresent(DriveState.self, forKey: .driveState)

--- a/TeslaSwiftTests/TeslaSwiftTests.swift
+++ b/TeslaSwiftTests/TeslaSwiftTests.swift
@@ -220,7 +220,7 @@ class TeslaSwiftTests: XCTestCase {
 			}.done { (response) -> Void in
 				
 				XCTAssertEqual(response.userId, 1234)
-				XCTAssertEqual(response.chargeState?.chargingState, .Disconnected)
+				XCTAssertEqual(response.chargeState?.chargingState, .disconnected)
 				XCTAssertEqual(response.vehicleConfig?.trimBadging, "85")
 				
 				expection.fulfill()
@@ -254,7 +254,7 @@ class TeslaSwiftTests: XCTestCase {
 				service.getVehicleChargeState(vehicles[0])
 			}.done { (response) -> Void in
 				
-				XCTAssertEqual(response.chargingState, .Complete)
+				XCTAssertEqual(response.chargingState, .complete)
 				XCTAssertEqual(response.ratedBatteryRange?.miles, 200.0)
 				XCTAssertEqual(response.batteryHeaterOn, true)
 				
@@ -1194,11 +1194,12 @@ class TeslaSwiftTests: XCTestCase {
         service.useMockServer = true
         let expection = expectation(description: "All Done")
         var order = 0
-        
+        let stream = TeslaStreaming(teslaSwift: service)
+
         service.authenticate(email: "user", password: "pass").then { (token) in
                 service.getVehicles()
 			}.done { (vehicles: [Vehicle]) in
-				service.openStream(vehicle: vehicles[0], dataReceived: {
+                stream.openStream(vehicle: vehicles[0], dataReceived: {
 					(event: TeslaStreamingEvent) in
 
                     switch event {


### PR DESCRIPTION
In `vechicle_data` API's response, `user_id` and `vehicle_id` is represented as a range of value in `Int64` type and these fields are treated as `Int` type in this library. 

Apple Watch Series4 and later is working with arm64 + 32 bit pointer mode. It means `Int` type is interpreted as `Int32`. This will cause an JSON decode error with the following error:

```
ERROR: dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "response", intValue: nil),
CodingKeys(stringValue: "user_id", intValue: nil)], debugDescription: "Parsed JSON number <18699999903> does not fit in
Int.", underlyingError: nil))
```

This PR changes the type of `userId` and `vehicleId` from `Int` to `Int64`. And this PR also fixes some compile errors in  UnitTests.
