### PR TITLE
Remove @available wrappers for Xcode 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "TeslaSwift",
     platforms: [
-        .macOS(.v10_12), .iOS(.v10), .watchOS(.v3), .tvOS(.v10)
+        .macOS(.v10_15), .iOS(.v13), .watchOS(.v6), .tvOS(.v13)
     ],
     products: [
         .library(name: "TeslaSwift", targets: ["TeslaSwift"]),

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Swift library to access Tesla API based on [Tesla JSON API (Unofficial)](https:/
 
 [![Swift](https://img.shields.io/badge/Swift-5.3-orange.svg?style=flat)](https://swift.org)
 [![Build Status](https://travis-ci.org/jonasman/TeslaSwift.svg?branch=master)](https://travis-ci.org/jonasman/TeslaSwift)
-[![TeslaSwift](https://img.shields.io/cocoapods/v/TeslaSwift.svg)](https://github.com/jonasman/TeslaSwift)
+[![TeslaSwift](https://img.shields.io/cocoapods/v/TeslaSwift.svg)](https://github.com/corear/TeslaSwift)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Swift library to access Tesla API based on [Tesla JSON API (Unofficial)](https:/
 
 [![Swift](https://img.shields.io/badge/Swift-5.3-orange.svg?style=flat)](https://swift.org)
 [![Build Status](https://travis-ci.org/jonasman/TeslaSwift.svg?branch=master)](https://travis-ci.org/jonasman/TeslaSwift)
-[![TeslaSwift](https://img.shields.io/cocoapods/v/TeslaSwift.svg)](https://github.com/corear/TeslaSwift)
+[![TeslaSwift](https://img.shields.io/cocoapods/v/TeslaSwift.svg)](https://github.com/jonasman/TeslaSwift)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ http://ts.la/joao290
 * Charged - for Tesla (https://getcharged.app/)
 * TeSlate (https://infinytum.co/)
 * Companion for Tesla - oAuth - (https://teslacompanion.app)
+* Pilot Log for Tesla (https://itunes.apple.com/us/app/pilot-log-for-Tesla/id1564398488?mt=8)
+* EV Companion (https://itunes.apple.com/us/app/ev-companion/id1574209459?mt=8)
 
 Missing your app? open a PR or issue
 

--- a/Sources/Extensions/Combine/TeslaSwift+Combine.swift
+++ b/Sources/Extensions/Combine/TeslaSwift+Combine.swift
@@ -13,7 +13,6 @@ import Combine
 import TeslaSwift
 #endif
 
-@available(iOS 13.0, macOS 10.15, watchOS 6, tvOS 13, *)
 extension TeslaSwift {
     
     func resultify<Value: Decodable>(subscriber: @escaping (Result<Value, Error>) -> Void) -> ((Result<Value, Error>) -> ()) {

--- a/Sources/Extensions/StreamingCombine/TeslaSwift+StreamingCombine.swift
+++ b/Sources/Extensions/StreamingCombine/TeslaSwift+StreamingCombine.swift
@@ -14,7 +14,6 @@ import TeslaSwift
 import TeslaSwiftStreaming
 #endif
 
-@available(iOS 13.0, macOS 10.15, watchOS 6, tvOS 13, *)
 extension TeslaStreaming  {
 
     public func streamPublisher(vehicle: Vehicle) -> TeslaStreamingPublisher {

--- a/Sources/TeslaSwift/Model/Authentication.swift
+++ b/Sources/TeslaSwift/Model/Authentication.swift
@@ -144,7 +144,6 @@ class AuthTokenRequestWeb: Encodable {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
 class AuthCodeRequest: Encodable {
 
     var responseType: String = "code"
@@ -196,7 +195,6 @@ extension String {
         return verifier
     }
 
-    @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
     var challenge: String {
         let hash = self.sha256
         let challenge = hash.base64EncodedString()
@@ -207,7 +205,6 @@ extension String {
         return challenge
     }
 
-    @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
     var sha256:String {
         get {
             let inputData = Data(self.utf8)

--- a/Sources/TeslaSwift/TeslaEndpoint.swift
+++ b/Sources/TeslaSwift/TeslaEndpoint.swift
@@ -12,9 +12,7 @@ enum Endpoint {
 	
 	case authentication
     case revoke
-    @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
     case oAuth2Authorization(auth: AuthCodeRequest)
-    @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
     case oAuth2AuthorizationCN(auth: AuthCodeRequest)
     case oAuth2Token
     case oAuth2TokenCN

--- a/Sources/TeslaSwift/TeslaSwift.swift
+++ b/Sources/TeslaSwift/TeslaSwift.swift
@@ -181,7 +181,7 @@ extension TeslaSwift {
      - returns: A ViewController that your app needs to present. This ViewController will ask the user for his/her Tesla credentials, MFA code if set and then dismiss on successful authentication
      */
     #if canImport(WebKit) && canImport(UIKit)
-	
+
     public func authenticateWeb(completion: @escaping (Result<AuthToken, Error>) -> ()) -> TeslaWebLoginViewController? {
 
         let codeRequest = AuthCodeRequest()

--- a/Sources/TeslaSwift/TeslaSwift.swift
+++ b/Sources/TeslaSwift/TeslaSwift.swift
@@ -181,7 +181,7 @@ extension TeslaSwift {
      - returns: A ViewController that your app needs to present. This ViewController will ask the user for his/her Tesla credentials, MFA code if set and then dismiss on successful authentication
      */
     #if canImport(WebKit) && canImport(UIKit)
-    @available(iOS 13.0, *)
+	
     public func authenticateWeb(completion: @escaping (Result<AuthToken, Error>) -> ()) -> TeslaWebLoginViewController? {
 
         let codeRequest = AuthCodeRequest()

--- a/TeslaSwift.podspec
+++ b/TeslaSwift.podspec
@@ -9,10 +9,10 @@ Pod::Spec.new do |s|
 
 	s.author             = { "Joao Nunes" => "joao3001@hotmail.com" }
 	s.social_media_url   = "https://twitter.com/jonas2man"
-	s.ios.deployment_target = '10.0'
-	s.osx.deployment_target = '10.12'
-	s.watchos.deployment_target = '3.0'
-	s.tvos.deployment_target = '10.0'
+	s.ios.deployment_target = '13.0'
+	s.osx.deployment_target = '10.15'
+	s.watchos.deployment_target = '6.0'
+	s.tvos.deployment_target = '13.0'
 	s.swift_version = '5.3'
 
 	s.source       = { :git => "https://github.com/jonasman/TeslaSwift.git", :tag => "#{s.version}" }

--- a/TeslaSwift.podspec
+++ b/TeslaSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name         = "TeslaSwift"
-	s.version      = "7.0.4"
+	s.version      = "7.0.5"
 	s.summary      = "Swift library to access the Tesla Model S, X, 3 and Y API."
 
 	s.homepage     = "https://github.com/jonasman/TeslaSwift"


### PR DESCRIPTION
I just removed the **`@available`** tags that were causing the errors in `/Sources/TeslaEndpoint`. Unsure if this will break the program for older iOS devices, but I think most targets should be of iOS 13 or newer anyway.