### PR TITLE
Missing event case in TeslaStreaming

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "PromiseKit",
-        "repositoryURL": "https://github.com/mxcl/PromiseKit",
-        "state": {
-          "branch": null,
-          "revision": "2fdb8c64a85e2081388532dbc61eb348a0793b1c",
-          "version": "6.10.0"
-        }
-      },
-      {
         "package": "RxSwift",
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {
           "branch": null,
-          "revision": "97e14358a3e6564de8a6289362385a92d85936e1",
-          "version": "6.0.0-rc.2"
+          "revision": "9dcaa4b333db437b0fbfaf453fad29069044a8b4",
+          "version": "6.6.0"
         }
       },
       {
@@ -24,8 +15,8 @@
         "repositoryURL": "https://github.com/daltoniam/Starscream.git",
         "state": {
           "branch": null,
-          "revision": "df8d82047f6654d8e4b655d1b1525c64e1059d21",
-          "version": "4.0.4"
+          "revision": "ac6c0fc9da221873e01bd1a0d4818498a71eef33",
+          "version": "4.0.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.5.0"),
-        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.4"),
+        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.6"),
         //.package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", Package.Dependency.Requirement.branch("feature/spm-support"))
     ],
     targets: [

--- a/Sources/Extensions/Streaming/TeslaStreaming.swift
+++ b/Sources/Extensions/Streaming/TeslaStreaming.swift
@@ -190,6 +190,8 @@ public class TeslaStreaming {
                     logDebug("Stream reconnectSuggested: \(reconnect)", debuggingEnabled: self.debuggingEnabled)
                 case .cancelled:
                     logDebug("Stream cancelled", debuggingEnabled: self.debuggingEnabled)
+                case .peerClosed:
+                    logDebug("peerClosed", debuggingEnabled: self.debuggingEnabled)
             }
         }
 		httpStreaming.connect()


### PR DESCRIPTION
Updated package StarScream from version 4.0.6, and added case .peerClosed in TeslaStreaming