### PR TITLE
Make partner api public

### DIFF
--- a/Sources/TeslaSwift/TeslaSwift.swift
+++ b/Sources/TeslaSwift/TeslaSwift.swift
@@ -59,7 +59,7 @@ open class TeslaSwift {
 }
 
 //MARK: Partner APIs
-extension TeslaSwift {
+public extension TeslaSwift {
 
     /**
      Retrieves a partner Auth token


### PR DESCRIPTION
Make partner API public so it can be called by importing TeslaSwift