### PR TITLE
EnergySite: add siteName and fix type

### DIFF
--- a/Sources/TeslaSwift/Model/EnergySite.swift
+++ b/Sources/TeslaSwift/Model/EnergySite.swift
@@ -22,11 +22,12 @@ open class EnergySite: Codable {
     public var siteId: SiteId {
         SiteId(id: energySiteID)
     }
+    open var siteName: String?
     open var assetSiteID: String?
     open var components: Components?
     open var goOffGridTestBannerEnabled: Bool?
     open var stormModeEnabled: Bool?
-    open var powerwallOnboardingSettingsSet: String?
+    open var powerwallOnboardingSettingsSet: Bool?
     open var powerwallTeslaElectricInterestedIn: String?
     open var vppTourEnabled: Bool?
 
@@ -44,6 +45,7 @@ open class EnergySite: Codable {
     open var breakerAlertEnabled: Bool
 
     enum CodingKeys: String, CodingKey {
+        case siteName = "site_name"
         case energySiteID = "energy_site_id"
         case resourceType = "resource_type"
         case warpSiteNumber = "warp_site_number"


### PR DESCRIPTION
I was getting parse data errors when getting a product `api.getProduct()` which for me is a powerwall. Also, I noticed that site name is missing so I added it. I am a little new to Swift so please be gentle. 😅 

Here is the JSON I get when calling `getProducts`

```json
{
  "response": [
    {
      "energy_site_id": 123456,
      "resource_type": "battery",
      "site_name": "MySite",
      "id": "STE20414-00692",
      "gateway_id": "442100-00-H--GF2231140002H0",
      "asset_site_id": "ee55b88d-62e3-4e07-aa07-ada493656bf6",
      "warp_site_number": "STE2041414-00692",
      "percentage_charged": 50.26227874809519,
      "battery_type": "ac_powerwall",
      "backup_capable": true,
      "battery_power": -2520,
      "go_off_grid_test_banner_enabled": null,
      "storm_mode_enabled": true,
      "powerwall_onboarding_settings_set": true,
      "powerwall_tesla_electric_interested_in": null,
      "vpp_tour_enabled": null,
      "sync_grid_alert_enabled": true,
      "breaker_alert_enabled": true,
      "components": {
        "battery": true,
        "battery_type": "ac_powerwall",
        "solar": true,
        "solar_type": "pv_panel",
        "grid": true,
        "load_meter": true,
        "market_type": "residential"
      },
      "charge_on_solar_capable": true,
      "features": { "rate_plan_manager_no_pricing_constraint": true }
    }
  ],
  "count": 1
}

```

FYI I also noticed that there is a lot of information which I require missing from the `getEnergySiteInfo(siteId)`. I am working on presenting information related to powerwall time of use workflows and none of this is present. I'll create a new PR with this change. 